### PR TITLE
feature/step8 api handler extension

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -15,19 +15,21 @@ var rootCmd = &cobalias.Command{
 	Use:   "kctl",
 	Short: "kctl is a custom Kubernetes controller CLI",
 	Long:  `"kctl" is a tool to test and run components of your custom Kubernetes controller`,
-	Run: func(cmd *cobalias.Command, args []string) {
+	PersistentPreRun: func(cmd *cobalias.Command, args []string) {
 		level := parseLogLevel(logLevel)
 		configureLogger(level)
+	},
+	Run: func(cmd *cobalias.Command, args []string) {
 		if len(args) == 0 {
 			_ = cmd.Help()
 			return
 		}
-		//log.Info().Msg("This is an info log")
-		//log.Debug().Msg("This is a debug log")
-		//log.Trace().Msg("This is a trace log")
-		//log.Warn().Msg("This is a warn log")
-		//log.Error().Msg("This is an error log")
-		//fmt.Println("")
+		log.Info().Msg("This is an info log")
+		log.Debug().Msg("This is a debug log")
+		log.Trace().Msg("This is a trace log")
+		log.Warn().Msg("This is a warn log")
+		log.Error().Msg("This is an error log")
+		fmt.Println("")
 	},
 }
 

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -28,7 +28,7 @@ var serverCmd = &cobra.Command{
 			os.Exit(1)
 		}
 		ctx := context.Background()
-		go informer.StartDeploymentInformer(ctx, clientset, namespace)
+		go informer.StartInformerFactory(ctx, clientset, namespace)
 		handler := func(ctx *fasthttp.RequestCtx) {
 			uuid := uuid.New().String()
 			switch string(ctx.Path()) {
@@ -45,6 +45,40 @@ var serverCmd = &cobra.Command{
 				if err != nil {
 					return
 				}
+			case "/deployments":
+				log.Info().Msg("Deployments request received")
+				ctx.Response.Header.Set("Content-Type", "application/json")
+				deployments := informer.GetDeploymentNames()
+				log.Info().Msgf("Deployments: %v", deployments)
+				ctx.SetStatusCode(200)
+				ctx.Write([]byte("["))
+				for i, name := range deployments {
+					ctx.WriteString("\"")
+					ctx.WriteString(name)
+					ctx.WriteString("\"")
+					if i < len(deployments)-1 {
+						ctx.WriteString(",")
+					}
+				}
+				ctx.Write([]byte("]"))
+				return
+			case "/secrets":
+				log.Info().Msg("Secrets request received")
+				ctx.Response.Header.Set("Content-Type", "application/json")
+				secrets := informer.GetSecretNames()
+				log.Info().Msgf("Secrets: %v", secrets)
+				ctx.SetStatusCode(200)
+				ctx.Write([]byte("["))
+				for i, name := range secrets {
+					ctx.WriteString("\"")
+					ctx.WriteString(name)
+					ctx.WriteString("\"")
+					if i < len(secrets)-1 {
+						ctx.WriteString(",")
+					}
+				}
+				ctx.Write([]byte("]"))
+				return
 			default:
 				log.Info().
 					Str("request_id", uuid).

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -51,13 +51,13 @@ var serverCmd = &cobra.Command{
 				deployments := informer.GetDeploymentNames()
 				log.Info().Msgf("Deployments: %v", deployments)
 				ctx.SetStatusCode(200)
-				ctx.Write([]byte("["))
+				ctx.Write([]byte("[")) //nolint:errcheck
 				for i, name := range deployments {
-					ctx.WriteString("\"")
-					ctx.WriteString(name)
-					ctx.WriteString("\"")
+					ctx.WriteString("\"") //nolint:errcheck
+					ctx.WriteString(name) //nolint:errcheck
+					ctx.WriteString("\"") //nolint:errcheck
 					if i < len(deployments)-1 {
-						ctx.WriteString(",")
+						ctx.WriteString(",") //nolint:errcheck
 					}
 				}
 				ctx.Write([]byte("]"))
@@ -68,16 +68,16 @@ var serverCmd = &cobra.Command{
 				secrets := informer.GetSecretNames()
 				log.Info().Msgf("Secrets: %v", secrets)
 				ctx.SetStatusCode(200)
-				ctx.Write([]byte("["))
+				ctx.Write([]byte("[")) //nolint:errcheck
 				for i, name := range secrets {
-					ctx.WriteString("\"")
-					ctx.WriteString(name)
-					ctx.WriteString("\"")
+					ctx.WriteString("\"") //nolint:errcheck
+					ctx.WriteString(name) //nolint:errcheck
+					ctx.WriteString("\"") //nolint:errcheck
 					if i < len(secrets)-1 {
-						ctx.WriteString(",")
+						ctx.WriteString(",") //nolint:errcheck
 					}
 				}
-				ctx.Write([]byte("]"))
+				ctx.Write([]byte("]")) //nolint:errcheck
 				return
 			default:
 				log.Info().

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -60,7 +60,7 @@ var serverCmd = &cobra.Command{
 						ctx.WriteString(",") //nolint:errcheck
 					}
 				}
-				ctx.Write([]byte("]"))
+				ctx.Write([]byte("]")) //nolint:errcheck
 				return
 			case "/secrets":
 				log.Info().Msg("Secrets request received")

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/rs/zerolog v1.34.0
 	github.com/spf13/cobra v1.9.1
 	github.com/valyala/fasthttp v1.62.0
+	k8s.io/api v0.33.2
 	k8s.io/apimachinery v0.33.2
 	k8s.io/client-go v0.33.2
 )
@@ -47,7 +48,6 @@ require (
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/api v0.33.2 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20250318190949-c8a335a9a2ff // indirect
 	k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738 // indirect

--- a/go.sum
+++ b/go.sum
@@ -105,6 +105,8 @@ github.com/xyproto/randomstring v1.0.5 h1:YtlWPoRdgMu3NZtP45drfy1GKoojuR7hmRcnhZ
 github.com/xyproto/randomstring v1.0.5/go.mod h1:rgmS5DeNXLivK7YprL0pY+lTuhNQW3iGxZ18UQApw/E=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
+go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
+go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=


### PR DESCRIPTION
- **list deployment added in respect to the namespace value**
- **delete operation added**
- **create is added**
- **informer with deploy and secrets added**
- **informer added + tested, able to watch secrets and deploys in the selected namespace**
- **error handling to pass the lint, better CLI experience with more intuitive key for NS which will be watched by the informer**
- **Persistent Pre run added to root in order to initialize logger first, added /deployemts and /secrets endpoints, fixed cache scope in Informer Factory**
- **//nolint:errcheck for write in controller**
- **//nolint:errcheck for write in controller + 1**
